### PR TITLE
Trigger action on push to main branch only

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -1,5 +1,9 @@
 name: Run gittuf demo
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: ['main']
+  pull_request:
+  workflow_dispatch:
 jobs:
   run-demo:
     name: Run demo


### PR DESCRIPTION
We don't want to duplicate the demo run workflow on pushes to non-main branches.