### PR TITLE
Feature/extend manual script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 gpg-dir
+.venv

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ cd gittuf
 make
 ```
 
+## Install Dependencies
+
+Download the required Python dependencies:
+
+```bash
+# (optional) create a new virtual environment
+python -m pip venv .venv
+source .venv/bin/activate
+# install dependencies
+python -m pip install -r requirements.txt
+```
+
 ## Run Demo
 
 You can run the scripted demo with commentary using the run-demo script.

--- a/run-demo.py
+++ b/run-demo.py
@@ -36,7 +36,7 @@ def display_command(cmd):
 
 
 def setup_gpg_keys(gpg_dir):
-    os.mkdir(gpg_dir)
+    os.mkdir(gpg_dir, mode=0o700)
 
     gpg = gnupg.GPG(gnupghome=gpg_dir)
     gpg.encoding = "utf-8"


### PR DESCRIPTION
A set of three changes (split into commits) I noticed when taking demo for a deep dive:

1. Add dependency installation for users less familiar with Python
2. Fix permissions for gpg folder as it produced warnings in demo script
3. Extend manual script to cover key generation

I also left two TODOs in the appropriate places:
1. I feel `signing_mechanism` should have documented valid options, or hard-coded if only value
2. When gittuf prints the usage information on verification error, I wasn't sure whether it's an actual verification error or me (user error) using the CLI wrong. See https://github.com/gittuf/gittuf/pull/228