### PR TITLE
Sign all commits

### DIFF
--- a/run-demo.py
+++ b/run-demo.py
@@ -63,6 +63,9 @@ def run_demo():
     cmd = f"git config --local gpg.format ssh"
     display_command(cmd)
     subprocess.call(shlex.split(cmd))
+    cmd = f"git config --local commit.gpgsign true"
+    display_command(cmd)
+    subprocess.call(shlex.split(cmd))
     cmd = f"git config --local user.signingkey {authorized_key_path_git}"
     display_command(cmd)
     subprocess.call(shlex.split(cmd))


### PR DESCRIPTION
The config for the demo wasn't set to sign all commits, and this led to `verify-commit HEAD` failing in envs that didn't globally sign all commits.