### PR TITLE
Update gittuf version and fix key issue

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install gittuf
         uses: gittuf/gittuf-installer@bb2e6c13c0825057e48e931b686d61c3b6267ef8
         with:
-          gittuf-version: 0.4.0
+          gittuf-version: 0.5.1
       - name: Run demo with --no-prompt
         run: |
           python3 run-demo.py --no-prompt

--- a/run-demo.py
+++ b/run-demo.py
@@ -9,7 +9,7 @@ import tempfile
 
 
 NO_PROMPT = False
-REQUIRED_BINARIES = ["git", "gittuf", "gpg"]
+REQUIRED_BINARIES = ["git", "gittuf", "ssh-keygen"]
 
 
 def check_binaries():
@@ -52,7 +52,7 @@ def run_demo():
     authorized_key_path_git = os.path.join(tmp_keys_dir, "authorized.pub")
     unauthorized_key_path_git = os.path.join(tmp_keys_dir, "unauthorized.pub")
 
-    authorized_key_path_policy = os.path.join(tmp_keys_dir, "authorized.pem")
+    authorized_key_path_policy = os.path.join(tmp_keys_dir, "authorized.pub")
 
     prompt_key("Initialize Git repository")
     cmd = "git init -b main"
@@ -89,7 +89,7 @@ def run_demo():
     cmd = (
         "gittuf trust add-policy-key"
         " -k ../keys/root"
-        " --policy-key ../keys/targets.pem"
+        " --policy-key ../keys/targets.pub"
     )
     display_command(cmd)
     subprocess.call(shlex.split(cmd))


### PR DESCRIPTION
This PR...

- Updates the gittuf version in the action for running the demo
- Resolves an issue with running the demo with `ssh-keygen` failing