### PR TITLE
Update demo with gittuf version v0.8.0

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install gittuf
         uses: gittuf/gittuf-installer@5c0fb4a2a0dc9434598cf2e74bb601d76861fc97
         with:
-          gittuf-version: 0.6.0
+          gittuf-version: 0.8.0
       - name: Run demo with --no-prompt
         run: |
           python3 run-demo.py --no-prompt

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ created to test the release workflow.  Alternatively, gittuf can also be
 installed using `go install`.
 
 To build from source, clone the repository and run `make`. This will also run
-the test suite prior to installing gittuf. Note that Go 1.22 or higher is
+the test suite prior to installing gittuf. Note that Go 1.23 or higher is
 necessary to build gittuf.
 
 ```bash
@@ -76,6 +76,9 @@ gittuf trust init -k ../keys/root
 gittuf trust add-policy-key -k ../keys/root --policy-key ../keys/targets.pub
 
 gittuf policy init -k ../keys/targets
+
+# Add key definition to policy
+gittuf policy add-key -k ../keys/targets --public-key ../keys/authorized.pub
 
 # Add branch protection rule
 gittuf policy add-rule -k ../keys/targets --rule-name 'protect-main' --rule-pattern git:refs/heads/main --authorize-key ../keys/authorized.pub

--- a/run-demo.py
+++ b/run-demo.py
@@ -99,6 +99,15 @@ def run_demo():
     display_command(cmd)
     subprocess.call(shlex.split(cmd))
 
+    prompt_key("Add key definition to policy")
+    cmd = (
+        "gittuf policy add-key"
+        " -k ../keys/targets"
+        " --public-key ../keys/authorized.pub"
+    )
+    display_command(cmd)
+    subprocess.call(shlex.split(cmd))
+
     prompt_key("Add rule to protect the main branch")
     cmd = (
         "gittuf policy add-rule"


### PR DESCRIPTION
This PR updates the demo to use the latest gittuf version, v0.8.0, and fixes an issue with `--authorize-key`.