### PR TITLE
ci: Use latest gittuf version

### DIFF
--- a/.github/workflows/run-demo.yml
+++ b/.github/workflows/run-demo.yml
@@ -17,8 +17,6 @@ jobs:
           python-version: '3.12'
       - name: Install gittuf
         uses: gittuf/gittuf-installer@f31e69c7c18c7473cbce18ed69a559b945d3a738
-        with:
-          gittuf-version: 0.8.0
       - name: Run demo with --no-prompt
         run: |
           python3 run-demo.py --no-prompt


### PR DESCRIPTION
This PR has CI use the latest version of gittuf provided by `gittuf-installer`.