### PR TITLE
fix deprecated authorize flag issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,11 @@ gittuf policy init -k ../keys/targets
 # Add key definition to policy
 gittuf policy add-key -k ../keys/targets --public-key ../keys/authorized.pub
 
+# Add trusted person to gittuf policy file
+gittuf policy add-person --person-ID 'authorized-user' --public-key ../keys/authorized.pub
+
 # Add branch protection rule
-gittuf policy add-rule -k ../keys/targets --rule-name 'protect-main' --rule-pattern git:refs/heads/main --authorize-key ../keys/authorized.pub
+gittuf policy add-rule -k ../keys/targets --rule-name 'protect-main' --rule-pattern git:refs/heads/main --authorize authorized-user
 
 # Stage and apply policy
 gittuf policy stage --local-only
@@ -114,7 +117,7 @@ git update-ref refs/gittuf/reference-state-log refs/gittuf/reference-state-log~1
 git config --local user.signingkey ../keys/authorized
 
 # Add file protection rule
-gittuf policy add-rule -k ../keys/targets --rule-name 'protect-readme' --rule-pattern file:README.md --authorize-key ../keys/authorized.pub
+gittuf policy add-rule -k ../keys/targets --rule-name 'protect-readme' --rule-pattern file:README.md --authorize authorized-user
 
 # Stage and apply policy
 gittuf policy stage --local-only

--- a/run-demo.py
+++ b/run-demo.py
@@ -49,7 +49,7 @@ def run_demo():
     for key in os.listdir(tmp_keys_dir):
         os.chmod(os.path.join(tmp_keys_dir, key), 0o600)
 
-    authorized_key_path_git = os.path.join(tmp_keys_dir, "authorized.pub")
+    authorized_key_path_git = os.path.join(tmp_keys_dir, "authorized")
     unauthorized_key_path_git = os.path.join(tmp_keys_dir, "unauthorized.pub")
 
     authorized_key_path_policy = os.path.join(tmp_keys_dir, "authorized.pub")
@@ -99,6 +99,16 @@ def run_demo():
     display_command(cmd)
     subprocess.call(shlex.split(cmd))
 
+    prompt_key("Add trusted person to gittuf policy file")
+    cmd = (
+        "gittuf policy add-person"
+        " --person-ID 'authorized-user'"
+        f" --public-key {authorized_key_path_policy}"
+        " -k ../keys/targets"
+    )
+    display_command(cmd)
+    subprocess.call(shlex.split(cmd))
+
     prompt_key("Add key definition to policy")
     cmd = (
         "gittuf policy add-key"
@@ -114,7 +124,7 @@ def run_demo():
         " -k ../keys/targets"
         " --rule-name 'protect-main'"
         " --rule-pattern git:refs/heads/main"
-        f" --authorize-key {authorized_key_path_policy}"
+        " --authorize authorized-user"
     )
     display_command(cmd)
     subprocess.call(shlex.split(cmd))
@@ -201,7 +211,7 @@ def run_demo():
         " -k ../keys/targets"
         " --rule-name 'protect-readme'"
         " --rule-pattern file:README.md"
-        f" --authorize-key {authorized_key_path_policy}"
+        " --authorize authorized-user"
     )
     display_command(cmd)
     subprocess.call(shlex.split(cmd))


### PR DESCRIPTION
gittuf policy flag "--authorize-key" is deprecated. 

So, this pull request changes "--authorize-key" with "--authorize" flag.

There are 4 instances of the flag in README.md and run-demo.py files which have been changed.